### PR TITLE
Sistemazione JSON A1111DSPSRLXXXXX - DSP - HCSuite - v4.3.0

### DIFF
--- a/GATEWAY/A1111DSPSRLXXXXX/DSP/HCSuite/v4.3.0/data.json
+++ b/GATEWAY/A1111DSPSRLXXXXX/DSP/HCSuite/v4.3.0/data.json
@@ -16,7 +16,7 @@
             "id": 154,
             "ts": "12-02-2024T11:01:29Z",
             "traceId": "f995018286f786cf",
-            "workflowInstanceId": :"2.16.840.1.113883.2.9.2.30.4.4.450f8bb2afeb8259d4e15b7d5ac1266bc122025ef0f89be954f0115226ce30b4.a88961f3f2^^^^urn:ihe:iti:xdw:2013:workflowInstanceId",
+            "workflowInstanceId":"2.16.840.1.113883.2.9.2.30.4.4.450f8bb2afeb8259d4e15b7d5ac1266bc122025ef0f89be954f0115226ce30b4.a88961f3f2^^^^urn:ihe:iti:xdw:2013:workflowInstanceId",
             "files": [
                 "20240205_CT8_154.pdf"
             ]


### PR DESCRIPTION
Tolti i ":" doppi che causavano l'errore "Data json malformato,non è stato possibile analizzarlo da git"