### PR TITLE
Allineamento versione NBS/NETWORKSANITARIO/V.4.10.106 in json versioni equivalenti

### DIFF
--- a/GATEWAY/S1#111NBSSRLXXXXX/NBS/networksanitario/v.4.10.106/versions.json
+++ b/GATEWAY/S1#111NBSSRLXXXXX/NBS/networksanitario/v.4.10.106/versions.json
@@ -1,11 +1,11 @@
 {
     	"appVendor": "NBS",
     	"appID": "networksanitario",
-    	"appVersion": "4.10.106",
+    	"appVersion": "v.4.10.106",
     	"ts":"2023-01-12T17:39:29Z",
 		"equiv_releases": [
 			"4.10.387",
 			"4.10.391",
 			"4.10.395"
 		]
-  }
+}


### PR DESCRIPTION
Allineamento versione NBS/NETWORKSANITARIO/V.4.10.106 in json versioni equivalenti, per consentire il corretto riconoscimento delle versioni equivalenti riconducibili all'applicativo