### PR TITLE
Fix `version.json` of vendor ENDOXWEB/25.0

### DIFF
--- a/GATEWAY/A1#111GRUPPOGPI00/TESI_SPA/ENDOXWEB/25.0/versions.json
+++ b/GATEWAY/A1#111GRUPPOGPI00/TESI_SPA/ENDOXWEB/25.0/versions.json
@@ -1,12 +1,12 @@
 {
-    "appVendor": "TESI SPA",
-    "appID": "ENDOXWEB",
-    "appVersion": "25.0",
-    	"ts":"2024-10-11T11:10:00Z",
-		"equiv_releases": [
-			"26.0",
-			"27.0",
-			"27.1",
-			"28.0",
-		]
-  }
+  "appVendor": "TESI SPA",
+  "appID": "ENDOXWEB",
+  "appVersion": "25.0",
+  "ts": "2024-10-11T11:10:00Z",
+  "equiv_releases": [
+    "26.0",
+    "27.0",
+    "27.1",
+    "28.0"
+  ]
+}


### PR DESCRIPTION
This PR fixes a problem with a JSON file not respecting standard Json syntax.