### PR TITLE
 Accreditamento A1#111#HEALTHTELEMATICNETWORKSRLXX (HTN Virtual Hospital) - Seconda submission

### DIFF
--- a/GATEWAY/A1#111#HEALTHTELEMATICNETWORKSRLXX/Health_Telematic_Network_S.r.l./HTN_Virtual_Hospital/3.0/data.json
+++ b/GATEWAY/A1#111#HEALTHTELEMATICNETWORKSRLXX/Health_Telematic_Network_S.r.l./HTN_Virtual_Hospital/3.0/data.json
@@ -1,6 +1,6 @@
 {
     "appVendor": "Health Telematic Network S.r.l.",
-    "appId": "HTN Virtual Hospital",
+    "appID": "HTN Virtual Hospital",
     "appVersion": "3.0",
     "results": [
         {


### PR DESCRIPTION
- commonName auth: `A1#111#HEALTHTELEMATICNETWORKSRLXX`
- subject_application_vendor: `Health Telematic Network S.r.l.`
- subject_application_id: `HTN Virtual Hospital`
- subject_application_version: `3.0`

---

Risolve errore:

```json
[ {
  "error" : "DATA_JSON_BASIC_INFO_MALFORMED",
  "description" : "Informazioni Fornitore malformati.Assicurarsi che i campi appVendor,appId,appVersion risultino valorizzati"
} ]
```
segnalato in risposta alla PR #2031.

Potete confermare il problema è dovuto al naming del campo `appId` (invece di `appID`, case sensitive)?

Grazie