### PR TITLE
Dichiarazione di versioni equivalenti

### DIFF
--- a/GATEWAY/S1#111DEDALUS0000/DEDALUS_SPA/LABMANAGER/1.1.1/versions.json
+++ b/GATEWAY/S1#111DEDALUS0000/DEDALUS_SPA/LABMANAGER/1.1.1/versions.json
@@ -1,0 +1,9 @@
+{
+	"appVendor": "DEDALUS SPA",
+	"appID": "LABMANAGER",
+	"appVersion": "1.1.1",
+	"ts": "2025-07-01T12:00:00Z",
+	"equiv_releases": [
+		"2.0.0"
+	]
+}


### PR DESCRIPTION
Autodichiarazione dell’equivalenza tra la versione di software già validata (1.1.1) e la sua release successiva (2.0.0). 