### PR TITLE
Dichiarazione di versioni equivalenti

### DIFF
--- a/GATEWAY/A1#111#EBNEUROSPAXX/EBNeuro/Galileo/4.60/versions.json
+++ b/GATEWAY/A1#111#EBNEUROSPAXX/EBNeuro/Galileo/4.60/versions.json
@@ -1,0 +1,9 @@
+{
+    	"appVendor": "EBNEURO",
+    	"appID": "Galileo",
+    	"appVersion": "4.60",
+    	"ts":"2025-11-25T10:00:00Z",
+		  "equiv_releases": [
+			     "4.52"
+		  ]
+}


### PR DESCRIPTION
Dichiariamo equivalenza software tra la versione 4.60 già accreditata e la versione 4.52, anche se la versione ha un numero inferiore per ragioni commerciali è stata generata dopo la versione 4.60 e contiene gli stessi moduli per FSE 2.0