### PR TITLE
Dichiarazione di versioni equivalenti - MARGHERITATRE

### DIFF
--- a/GATEWAY/A1#111MEDIACLINICS/MEDIACLINICS_ITALIA/MARGHERITATRE/V.3.3.0/versions.json
+++ b/GATEWAY/A1#111MEDIACLINICS/MEDIACLINICS_ITALIA/MARGHERITATRE/V.3.3.0/versions.json
@@ -1,0 +1,10 @@
+{
+    "appVendor": "MEDIACLINICS ITALIA",
+    "appID": "MargheritaTre",
+    "appVersion": "V.3.3.0",
+    "ts": "2025-11-26T10:00:29Z",
+    "equiv_releases": [
+        "V.3.7.0",
+        "CORE.1.0.0"
+    ]
+}


### PR DESCRIPTION
Dichiariamo equivalenza software tra la versione 3.3.0 già accreditata e le versioni 3.7.0 e 1.0.0, nonostante sia presente una versione con numero inferiore i moduli e logiche utilizzate rimangono gli stessi.